### PR TITLE
report has sections

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -933,6 +933,19 @@ run();
 
 /***/ }),
 
+/***/ 109:
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+"use strict";
+
+
+var truncate = __webpack_require__(423);
+var getLength = Buffer.byteLength.bind(Buffer);
+module.exports = truncate.bind(null, getLength);
+
+
+/***/ }),
+
 /***/ 118:
 /***/ (function(module, __unusedexports, __webpack_require__) {
 
@@ -1159,7 +1172,7 @@ function getIssueCard(token, card, projectId) {
             per_page: 100
         });
         issueCard.events = [];
-        console.log(res.data);
+        // console.log(res.data);
         for (const cardEvent of res.data) {
             let newEvent = {
                 event: cardEvent.event,
@@ -1335,6 +1348,752 @@ module.exports = opts => {
 
 	return result;
 };
+
+
+/***/ }),
+
+/***/ 174:
+/***/ (function(module) {
+
+// This file has been generated from mustache.mjs
+(function (global, factory) {
+   true ? module.exports = factory() :
+  undefined;
+}(this, (function () { 'use strict';
+
+  /*!
+   * mustache.js - Logic-less {{mustache}} templates with JavaScript
+   * http://github.com/janl/mustache.js
+   */
+
+  var objectToString = Object.prototype.toString;
+  var isArray = Array.isArray || function isArrayPolyfill (object) {
+    return objectToString.call(object) === '[object Array]';
+  };
+
+  function isFunction (object) {
+    return typeof object === 'function';
+  }
+
+  /**
+   * More correct typeof string handling array
+   * which normally returns typeof 'object'
+   */
+  function typeStr (obj) {
+    return isArray(obj) ? 'array' : typeof obj;
+  }
+
+  function escapeRegExp (string) {
+    return string.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, '\\$&');
+  }
+
+  /**
+   * Null safe way of checking whether or not an object,
+   * including its prototype, has a given property
+   */
+  function hasProperty (obj, propName) {
+    return obj != null && typeof obj === 'object' && (propName in obj);
+  }
+
+  /**
+   * Safe way of detecting whether or not the given thing is a primitive and
+   * whether it has the given property
+   */
+  function primitiveHasOwnProperty (primitive, propName) {
+    return (
+      primitive != null
+      && typeof primitive !== 'object'
+      && primitive.hasOwnProperty
+      && primitive.hasOwnProperty(propName)
+    );
+  }
+
+  // Workaround for https://issues.apache.org/jira/browse/COUCHDB-577
+  // See https://github.com/janl/mustache.js/issues/189
+  var regExpTest = RegExp.prototype.test;
+  function testRegExp (re, string) {
+    return regExpTest.call(re, string);
+  }
+
+  var nonSpaceRe = /\S/;
+  function isWhitespace (string) {
+    return !testRegExp(nonSpaceRe, string);
+  }
+
+  var entityMap = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+    '/': '&#x2F;',
+    '`': '&#x60;',
+    '=': '&#x3D;'
+  };
+
+  function escapeHtml (string) {
+    return String(string).replace(/[&<>"'`=\/]/g, function fromEntityMap (s) {
+      return entityMap[s];
+    });
+  }
+
+  var whiteRe = /\s*/;
+  var spaceRe = /\s+/;
+  var equalsRe = /\s*=/;
+  var curlyRe = /\s*\}/;
+  var tagRe = /#|\^|\/|>|\{|&|=|!/;
+
+  /**
+   * Breaks up the given `template` string into a tree of tokens. If the `tags`
+   * argument is given here it must be an array with two string values: the
+   * opening and closing tags used in the template (e.g. [ "<%", "%>" ]). Of
+   * course, the default is to use mustaches (i.e. mustache.tags).
+   *
+   * A token is an array with at least 4 elements. The first element is the
+   * mustache symbol that was used inside the tag, e.g. "#" or "&". If the tag
+   * did not contain a symbol (i.e. {{myValue}}) this element is "name". For
+   * all text that appears outside a symbol this element is "text".
+   *
+   * The second element of a token is its "value". For mustache tags this is
+   * whatever else was inside the tag besides the opening symbol. For text tokens
+   * this is the text itself.
+   *
+   * The third and fourth elements of the token are the start and end indices,
+   * respectively, of the token in the original template.
+   *
+   * Tokens that are the root node of a subtree contain two more elements: 1) an
+   * array of tokens in the subtree and 2) the index in the original template at
+   * which the closing tag for that section begins.
+   *
+   * Tokens for partials also contain two more elements: 1) a string value of
+   * indendation prior to that tag and 2) the index of that tag on that line -
+   * eg a value of 2 indicates the partial is the third tag on this line.
+   */
+  function parseTemplate (template, tags) {
+    if (!template)
+      return [];
+    var lineHasNonSpace = false;
+    var sections = [];     // Stack to hold section tokens
+    var tokens = [];       // Buffer to hold the tokens
+    var spaces = [];       // Indices of whitespace tokens on the current line
+    var hasTag = false;    // Is there a {{tag}} on the current line?
+    var nonSpace = false;  // Is there a non-space char on the current line?
+    var indentation = '';  // Tracks indentation for tags that use it
+    var tagIndex = 0;      // Stores a count of number of tags encountered on a line
+
+    // Strips all whitespace tokens array for the current line
+    // if there was a {{#tag}} on it and otherwise only space.
+    function stripSpace () {
+      if (hasTag && !nonSpace) {
+        while (spaces.length)
+          delete tokens[spaces.pop()];
+      } else {
+        spaces = [];
+      }
+
+      hasTag = false;
+      nonSpace = false;
+    }
+
+    var openingTagRe, closingTagRe, closingCurlyRe;
+    function compileTags (tagsToCompile) {
+      if (typeof tagsToCompile === 'string')
+        tagsToCompile = tagsToCompile.split(spaceRe, 2);
+
+      if (!isArray(tagsToCompile) || tagsToCompile.length !== 2)
+        throw new Error('Invalid tags: ' + tagsToCompile);
+
+      openingTagRe = new RegExp(escapeRegExp(tagsToCompile[0]) + '\\s*');
+      closingTagRe = new RegExp('\\s*' + escapeRegExp(tagsToCompile[1]));
+      closingCurlyRe = new RegExp('\\s*' + escapeRegExp('}' + tagsToCompile[1]));
+    }
+
+    compileTags(tags || mustache.tags);
+
+    var scanner = new Scanner(template);
+
+    var start, type, value, chr, token, openSection;
+    while (!scanner.eos()) {
+      start = scanner.pos;
+
+      // Match any text between tags.
+      value = scanner.scanUntil(openingTagRe);
+
+      if (value) {
+        for (var i = 0, valueLength = value.length; i < valueLength; ++i) {
+          chr = value.charAt(i);
+
+          if (isWhitespace(chr)) {
+            spaces.push(tokens.length);
+            indentation += chr;
+          } else {
+            nonSpace = true;
+            lineHasNonSpace = true;
+            indentation += ' ';
+          }
+
+          tokens.push([ 'text', chr, start, start + 1 ]);
+          start += 1;
+
+          // Check for whitespace on the current line.
+          if (chr === '\n') {
+            stripSpace();
+            indentation = '';
+            tagIndex = 0;
+            lineHasNonSpace = false;
+          }
+        }
+      }
+
+      // Match the opening tag.
+      if (!scanner.scan(openingTagRe))
+        break;
+
+      hasTag = true;
+
+      // Get the tag type.
+      type = scanner.scan(tagRe) || 'name';
+      scanner.scan(whiteRe);
+
+      // Get the tag value.
+      if (type === '=') {
+        value = scanner.scanUntil(equalsRe);
+        scanner.scan(equalsRe);
+        scanner.scanUntil(closingTagRe);
+      } else if (type === '{') {
+        value = scanner.scanUntil(closingCurlyRe);
+        scanner.scan(curlyRe);
+        scanner.scanUntil(closingTagRe);
+        type = '&';
+      } else {
+        value = scanner.scanUntil(closingTagRe);
+      }
+
+      // Match the closing tag.
+      if (!scanner.scan(closingTagRe))
+        throw new Error('Unclosed tag at ' + scanner.pos);
+
+      if (type == '>') {
+        token = [ type, value, start, scanner.pos, indentation, tagIndex, lineHasNonSpace ];
+      } else {
+        token = [ type, value, start, scanner.pos ];
+      }
+      tagIndex++;
+      tokens.push(token);
+
+      if (type === '#' || type === '^') {
+        sections.push(token);
+      } else if (type === '/') {
+        // Check section nesting.
+        openSection = sections.pop();
+
+        if (!openSection)
+          throw new Error('Unopened section "' + value + '" at ' + start);
+
+        if (openSection[1] !== value)
+          throw new Error('Unclosed section "' + openSection[1] + '" at ' + start);
+      } else if (type === 'name' || type === '{' || type === '&') {
+        nonSpace = true;
+      } else if (type === '=') {
+        // Set the tags for the next time around.
+        compileTags(value);
+      }
+    }
+
+    stripSpace();
+
+    // Make sure there are no open sections when we're done.
+    openSection = sections.pop();
+
+    if (openSection)
+      throw new Error('Unclosed section "' + openSection[1] + '" at ' + scanner.pos);
+
+    return nestTokens(squashTokens(tokens));
+  }
+
+  /**
+   * Combines the values of consecutive text tokens in the given `tokens` array
+   * to a single token.
+   */
+  function squashTokens (tokens) {
+    var squashedTokens = [];
+
+    var token, lastToken;
+    for (var i = 0, numTokens = tokens.length; i < numTokens; ++i) {
+      token = tokens[i];
+
+      if (token) {
+        if (token[0] === 'text' && lastToken && lastToken[0] === 'text') {
+          lastToken[1] += token[1];
+          lastToken[3] = token[3];
+        } else {
+          squashedTokens.push(token);
+          lastToken = token;
+        }
+      }
+    }
+
+    return squashedTokens;
+  }
+
+  /**
+   * Forms the given array of `tokens` into a nested tree structure where
+   * tokens that represent a section have two additional items: 1) an array of
+   * all tokens that appear in that section and 2) the index in the original
+   * template that represents the end of that section.
+   */
+  function nestTokens (tokens) {
+    var nestedTokens = [];
+    var collector = nestedTokens;
+    var sections = [];
+
+    var token, section;
+    for (var i = 0, numTokens = tokens.length; i < numTokens; ++i) {
+      token = tokens[i];
+
+      switch (token[0]) {
+        case '#':
+        case '^':
+          collector.push(token);
+          sections.push(token);
+          collector = token[4] = [];
+          break;
+        case '/':
+          section = sections.pop();
+          section[5] = token[2];
+          collector = sections.length > 0 ? sections[sections.length - 1][4] : nestedTokens;
+          break;
+        default:
+          collector.push(token);
+      }
+    }
+
+    return nestedTokens;
+  }
+
+  /**
+   * A simple string scanner that is used by the template parser to find
+   * tokens in template strings.
+   */
+  function Scanner (string) {
+    this.string = string;
+    this.tail = string;
+    this.pos = 0;
+  }
+
+  /**
+   * Returns `true` if the tail is empty (end of string).
+   */
+  Scanner.prototype.eos = function eos () {
+    return this.tail === '';
+  };
+
+  /**
+   * Tries to match the given regular expression at the current position.
+   * Returns the matched text if it can match, the empty string otherwise.
+   */
+  Scanner.prototype.scan = function scan (re) {
+    var match = this.tail.match(re);
+
+    if (!match || match.index !== 0)
+      return '';
+
+    var string = match[0];
+
+    this.tail = this.tail.substring(string.length);
+    this.pos += string.length;
+
+    return string;
+  };
+
+  /**
+   * Skips all text until the given regular expression can be matched. Returns
+   * the skipped string, which is the entire tail if no match can be made.
+   */
+  Scanner.prototype.scanUntil = function scanUntil (re) {
+    var index = this.tail.search(re), match;
+
+    switch (index) {
+      case -1:
+        match = this.tail;
+        this.tail = '';
+        break;
+      case 0:
+        match = '';
+        break;
+      default:
+        match = this.tail.substring(0, index);
+        this.tail = this.tail.substring(index);
+    }
+
+    this.pos += match.length;
+
+    return match;
+  };
+
+  /**
+   * Represents a rendering context by wrapping a view object and
+   * maintaining a reference to the parent context.
+   */
+  function Context (view, parentContext) {
+    this.view = view;
+    this.cache = { '.': this.view };
+    this.parent = parentContext;
+  }
+
+  /**
+   * Creates a new context using the given view with this context
+   * as the parent.
+   */
+  Context.prototype.push = function push (view) {
+    return new Context(view, this);
+  };
+
+  /**
+   * Returns the value of the given name in this context, traversing
+   * up the context hierarchy if the value is absent in this context's view.
+   */
+  Context.prototype.lookup = function lookup (name) {
+    var cache = this.cache;
+
+    var value;
+    if (cache.hasOwnProperty(name)) {
+      value = cache[name];
+    } else {
+      var context = this, intermediateValue, names, index, lookupHit = false;
+
+      while (context) {
+        if (name.indexOf('.') > 0) {
+          intermediateValue = context.view;
+          names = name.split('.');
+          index = 0;
+
+          /**
+           * Using the dot notion path in `name`, we descend through the
+           * nested objects.
+           *
+           * To be certain that the lookup has been successful, we have to
+           * check if the last object in the path actually has the property
+           * we are looking for. We store the result in `lookupHit`.
+           *
+           * This is specially necessary for when the value has been set to
+           * `undefined` and we want to avoid looking up parent contexts.
+           *
+           * In the case where dot notation is used, we consider the lookup
+           * to be successful even if the last "object" in the path is
+           * not actually an object but a primitive (e.g., a string, or an
+           * integer), because it is sometimes useful to access a property
+           * of an autoboxed primitive, such as the length of a string.
+           **/
+          while (intermediateValue != null && index < names.length) {
+            if (index === names.length - 1)
+              lookupHit = (
+                hasProperty(intermediateValue, names[index])
+                || primitiveHasOwnProperty(intermediateValue, names[index])
+              );
+
+            intermediateValue = intermediateValue[names[index++]];
+          }
+        } else {
+          intermediateValue = context.view[name];
+
+          /**
+           * Only checking against `hasProperty`, which always returns `false` if
+           * `context.view` is not an object. Deliberately omitting the check
+           * against `primitiveHasOwnProperty` if dot notation is not used.
+           *
+           * Consider this example:
+           * ```
+           * Mustache.render("The length of a football field is {{#length}}{{length}}{{/length}}.", {length: "100 yards"})
+           * ```
+           *
+           * If we were to check also against `primitiveHasOwnProperty`, as we do
+           * in the dot notation case, then render call would return:
+           *
+           * "The length of a football field is 9."
+           *
+           * rather than the expected:
+           *
+           * "The length of a football field is 100 yards."
+           **/
+          lookupHit = hasProperty(context.view, name);
+        }
+
+        if (lookupHit) {
+          value = intermediateValue;
+          break;
+        }
+
+        context = context.parent;
+      }
+
+      cache[name] = value;
+    }
+
+    if (isFunction(value))
+      value = value.call(this.view);
+
+    return value;
+  };
+
+  /**
+   * A Writer knows how to take a stream of tokens and render them to a
+   * string, given a context. It also maintains a cache of templates to
+   * avoid the need to parse the same template twice.
+   */
+  function Writer () {
+    this.templateCache = {
+      _cache: {},
+      set: function set (key, value) {
+        this._cache[key] = value;
+      },
+      get: function get (key) {
+        return this._cache[key];
+      },
+      clear: function clear () {
+        this._cache = {};
+      }
+    };
+  }
+
+  /**
+   * Clears all cached templates in this writer.
+   */
+  Writer.prototype.clearCache = function clearCache () {
+    if (typeof this.templateCache !== 'undefined') {
+      this.templateCache.clear();
+    }
+  };
+
+  /**
+   * Parses and caches the given `template` according to the given `tags` or
+   * `mustache.tags` if `tags` is omitted,  and returns the array of tokens
+   * that is generated from the parse.
+   */
+  Writer.prototype.parse = function parse (template, tags) {
+    var cache = this.templateCache;
+    var cacheKey = template + ':' + (tags || mustache.tags).join(':');
+    var isCacheEnabled = typeof cache !== 'undefined';
+    var tokens = isCacheEnabled ? cache.get(cacheKey) : undefined;
+
+    if (tokens == undefined) {
+      tokens = parseTemplate(template, tags);
+      isCacheEnabled && cache.set(cacheKey, tokens);
+    }
+    return tokens;
+  };
+
+  /**
+   * High-level method that is used to render the given `template` with
+   * the given `view`.
+   *
+   * The optional `partials` argument may be an object that contains the
+   * names and templates of partials that are used in the template. It may
+   * also be a function that is used to load partial templates on the fly
+   * that takes a single argument: the name of the partial.
+   *
+   * If the optional `tags` argument is given here it must be an array with two
+   * string values: the opening and closing tags used in the template (e.g.
+   * [ "<%", "%>" ]). The default is to mustache.tags.
+   */
+  Writer.prototype.render = function render (template, view, partials, tags) {
+    var tokens = this.parse(template, tags);
+    var context = (view instanceof Context) ? view : new Context(view, undefined);
+    return this.renderTokens(tokens, context, partials, template, tags);
+  };
+
+  /**
+   * Low-level method that renders the given array of `tokens` using
+   * the given `context` and `partials`.
+   *
+   * Note: The `originalTemplate` is only ever used to extract the portion
+   * of the original template that was contained in a higher-order section.
+   * If the template doesn't use higher-order sections, this argument may
+   * be omitted.
+   */
+  Writer.prototype.renderTokens = function renderTokens (tokens, context, partials, originalTemplate, tags) {
+    var buffer = '';
+
+    var token, symbol, value;
+    for (var i = 0, numTokens = tokens.length; i < numTokens; ++i) {
+      value = undefined;
+      token = tokens[i];
+      symbol = token[0];
+
+      if (symbol === '#') value = this.renderSection(token, context, partials, originalTemplate);
+      else if (symbol === '^') value = this.renderInverted(token, context, partials, originalTemplate);
+      else if (symbol === '>') value = this.renderPartial(token, context, partials, tags);
+      else if (symbol === '&') value = this.unescapedValue(token, context);
+      else if (symbol === 'name') value = this.escapedValue(token, context);
+      else if (symbol === 'text') value = this.rawValue(token);
+
+      if (value !== undefined)
+        buffer += value;
+    }
+
+    return buffer;
+  };
+
+  Writer.prototype.renderSection = function renderSection (token, context, partials, originalTemplate) {
+    var self = this;
+    var buffer = '';
+    var value = context.lookup(token[1]);
+
+    // This function is used to render an arbitrary template
+    // in the current context by higher-order sections.
+    function subRender (template) {
+      return self.render(template, context, partials);
+    }
+
+    if (!value) return;
+
+    if (isArray(value)) {
+      for (var j = 0, valueLength = value.length; j < valueLength; ++j) {
+        buffer += this.renderTokens(token[4], context.push(value[j]), partials, originalTemplate);
+      }
+    } else if (typeof value === 'object' || typeof value === 'string' || typeof value === 'number') {
+      buffer += this.renderTokens(token[4], context.push(value), partials, originalTemplate);
+    } else if (isFunction(value)) {
+      if (typeof originalTemplate !== 'string')
+        throw new Error('Cannot use higher-order sections without the original template');
+
+      // Extract the portion of the original template that the section contains.
+      value = value.call(context.view, originalTemplate.slice(token[3], token[5]), subRender);
+
+      if (value != null)
+        buffer += value;
+    } else {
+      buffer += this.renderTokens(token[4], context, partials, originalTemplate);
+    }
+    return buffer;
+  };
+
+  Writer.prototype.renderInverted = function renderInverted (token, context, partials, originalTemplate) {
+    var value = context.lookup(token[1]);
+
+    // Use JavaScript's definition of falsy. Include empty arrays.
+    // See https://github.com/janl/mustache.js/issues/186
+    if (!value || (isArray(value) && value.length === 0))
+      return this.renderTokens(token[4], context, partials, originalTemplate);
+  };
+
+  Writer.prototype.indentPartial = function indentPartial (partial, indentation, lineHasNonSpace) {
+    var filteredIndentation = indentation.replace(/[^ \t]/g, '');
+    var partialByNl = partial.split('\n');
+    for (var i = 0; i < partialByNl.length; i++) {
+      if (partialByNl[i].length && (i > 0 || !lineHasNonSpace)) {
+        partialByNl[i] = filteredIndentation + partialByNl[i];
+      }
+    }
+    return partialByNl.join('\n');
+  };
+
+  Writer.prototype.renderPartial = function renderPartial (token, context, partials, tags) {
+    if (!partials) return;
+
+    var value = isFunction(partials) ? partials(token[1]) : partials[token[1]];
+    if (value != null) {
+      var lineHasNonSpace = token[6];
+      var tagIndex = token[5];
+      var indentation = token[4];
+      var indentedValue = value;
+      if (tagIndex == 0 && indentation) {
+        indentedValue = this.indentPartial(value, indentation, lineHasNonSpace);
+      }
+      return this.renderTokens(this.parse(indentedValue, tags), context, partials, indentedValue, tags);
+    }
+  };
+
+  Writer.prototype.unescapedValue = function unescapedValue (token, context) {
+    var value = context.lookup(token[1]);
+    if (value != null)
+      return value;
+  };
+
+  Writer.prototype.escapedValue = function escapedValue (token, context) {
+    var value = context.lookup(token[1]);
+    if (value != null)
+      return mustache.escape(value);
+  };
+
+  Writer.prototype.rawValue = function rawValue (token) {
+    return token[1];
+  };
+
+  var mustache = {
+    name: 'mustache.js',
+    version: '4.0.1',
+    tags: [ '{{', '}}' ],
+    clearCache: undefined,
+    escape: undefined,
+    parse: undefined,
+    render: undefined,
+    Scanner: undefined,
+    Context: undefined,
+    Writer: undefined,
+    /**
+     * Allows a user to override the default caching strategy, by providing an
+     * object with set, get and clear methods. This can also be used to disable
+     * the cache by setting it to the literal `undefined`.
+     */
+    set templateCache (cache) {
+      defaultWriter.templateCache = cache;
+    },
+    /**
+     * Gets the default or overridden caching object from the default writer.
+     */
+    get templateCache () {
+      return defaultWriter.templateCache;
+    }
+  };
+
+  // All high-level mustache.* functions use this writer.
+  var defaultWriter = new Writer();
+
+  /**
+   * Clears all cached templates in the default writer.
+   */
+  mustache.clearCache = function clearCache () {
+    return defaultWriter.clearCache();
+  };
+
+  /**
+   * Parses and caches the given template in the default writer and returns the
+   * array of tokens it contains. Doing this ahead of time avoids the need to
+   * parse templates on the fly as they are rendered.
+   */
+  mustache.parse = function parse (template, tags) {
+    return defaultWriter.parse(template, tags);
+  };
+
+  /**
+   * Renders the `template` with the given `view` and `partials` using the
+   * default writer. If the optional `tags` argument is given here it must be an
+   * array with two string values: the opening and closing tags used in the
+   * template (e.g. [ "<%", "%>" ]). The default is to mustache.tags.
+   */
+  mustache.render = function render (template, view, partials, tags) {
+    if (typeof template !== 'string') {
+      throw new TypeError('Invalid template! Template should be a "string" ' +
+                          'but "' + typeStr(template) + '" was given as the first ' +
+                          'argument for mustache#render(template, view, partials)');
+    }
+
+    return defaultWriter.render(template, view, partials, tags);
+  };
+
+  // Export the escaping function so that the user may override it.
+  // See https://github.com/janl/mustache.js/issues/244
+  mustache.escape = escapeHtml;
+
+  // Export these mainly for testing, but also for advanced usage.
+  mustache.Scanner = Scanner;
+  mustache.Context = Context;
+  mustache.Writer = Writer;
+
+  return mustache;
+
+})));
 
 
 /***/ }),
@@ -4542,8 +5301,11 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.generate = void 0;
 const path = __importStar(__webpack_require__(622));
 const fs = __importStar(__webpack_require__(747));
+const util = __importStar(__webpack_require__(702));
 const yaml = __importStar(__webpack_require__(414));
 const github = __importStar(__webpack_require__(126));
+const mustache = __importStar(__webpack_require__(174));
+let sanitize = __webpack_require__(834);
 function generate(token, configYaml) {
     return __awaiter(this, void 0, void 0, function* () {
         console.log("Generating reports");
@@ -4556,30 +5318,47 @@ function generate(token, configYaml) {
         snapshot.config.output = snapshot.config.output || "_reports";
         // load up the projects, their columns and all the issue cards + events.
         let projectsData = yield loadProjectsData(token, config);
+        // update report config details
+        for (const report of config.reports) {
+            report.timezoneOffset = report.timezoneOffset || -8;
+            report.details = {
+                time: util.getTimeForOffset(snapshot.datetime, report.timezoneOffset)
+            };
+            console.log(report.details.time);
+            console.log(`Rendering ${report.name}`);
+            report.name = mustache.render(report.name, {
+                config: config,
+                report: report
+            });
+            console.log(report.name);
+        }
         let outPath = yield writeSnapshot(snapshot);
         // hand that full data set to each report to render
         for (const proj in projectsData) {
             const projectData = projectsData[proj];
-            for (const reportConfig of config.reports) {
-                console.log(`Generating ${reportConfig.name} for ${proj} ...`);
-                // TODO: offer a config setting for the report path.
-                //       this will allow reports to be cloned and run 
-                let reportModule = `./reports/${reportConfig.name}`;
-                if (!fs.existsSync(path.join(__dirname, `${reportModule}.js`))) {
-                    throw new Error(`Report not found: ${reportConfig.name}`);
+            for (const report of config.reports) {
+                let output = "";
+                console.log(`Generating ${report.name} for ${proj} ...`);
+                for (const reportSection of report.sections) {
+                    // TODO: offer a config setting for the report path.
+                    //       this will allow reports to be cloned and run 
+                    let reportModule = `./reports/${reportSection.name}`;
+                    if (!fs.existsSync(path.join(__dirname, `${reportModule}.js`))) {
+                        throw new Error(`Report not found: ${report.name}`);
+                    }
+                    // run as many reports as we can but fail action if any failed.
+                    let failed = [];
+                    try {
+                        let report = require(reportModule);
+                        let processed = report.process(projectData);
+                        output += report.render(processed);
+                    }
+                    catch (err) {
+                        console.error(`Failed: ${err.message}`);
+                        failed.push({ report: report.name, error: err });
+                    }
                 }
-                // run as many reports as we can but fail action if any failed.
-                let failed = [];
-                try {
-                    let report = require(reportModule);
-                    let processed = report.process(projectData);
-                    let contents = report.render(processed);
-                    writeReport(outPath, reportConfig, projectData, contents);
-                }
-                catch (err) {
-                    console.error(`Failed: ${err.message}`);
-                    failed.push({ report: reportConfig.name, error: err });
-                }
+                writeReport(outPath, report, projectData, output);
             }
         }
         // TODO: throw if failed length > 0
@@ -4604,9 +5383,9 @@ function writeSnapshot(snapshot) {
         return snapshotPath;
     });
 }
-function writeReport(basePath, reportConfig, projectData, contents) {
+function writeReport(basePath, report, projectData, contents) {
     return __awaiter(this, void 0, void 0, function* () {
-        const reportPath = path.join(basePath, reportConfig.name);
+        const reportPath = path.join(basePath, sanitize(report.name));
         if (!fs.existsSync(reportPath)) {
             fs.mkdirSync(reportPath);
         }
@@ -5406,6 +6185,57 @@ module.exports = new Type('tag:yaml.org,2002:float', {
   represent: representYamlFloat,
   defaultStyle: 'lowercase'
 });
+
+
+/***/ }),
+
+/***/ 423:
+/***/ (function(module) {
+
+"use strict";
+
+
+function isHighSurrogate(codePoint) {
+  return codePoint >= 0xd800 && codePoint <= 0xdbff;
+}
+
+function isLowSurrogate(codePoint) {
+  return codePoint >= 0xdc00 && codePoint <= 0xdfff;
+}
+
+// Truncate string by size in bytes
+module.exports = function truncate(getLength, string, byteLength) {
+  if (typeof string !== "string") {
+    throw new Error("Input must be string");
+  }
+
+  var charLength = string.length;
+  var curByteLength = 0;
+  var codePoint;
+  var segment;
+
+  for (var i = 0; i < charLength; i += 1) {
+    codePoint = string.charCodeAt(i);
+    segment = string[i];
+
+    if (isHighSurrogate(codePoint) && isLowSurrogate(string.charCodeAt(i + 1))) {
+      i += 1;
+      segment += string[i];
+    }
+
+    curByteLength += getLength(segment);
+
+    if (curByteLength === byteLength) {
+      return string.slice(0, i + 1);
+    }
+    else if (curByteLength > byteLength) {
+      return string.slice(0, i - segment.length + 1);
+    }
+  }
+
+  return string;
+};
+
 
 
 /***/ }),
@@ -11188,6 +12018,23 @@ module.exports = (promise, onFinally) => {
 
 /***/ }),
 
+/***/ 702:
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getTimeForOffset = void 0;
+function getTimeForOffset(date, offset) {
+    var utc = date.getTime() + (date.getTimezoneOffset() * 60000);
+    var nd = new Date(utc + (3600000 * offset));
+    return nd.toLocaleString();
+}
+exports.getTimeForOffset = getTimeForOffset;
+
+
+/***/ }),
+
 /***/ 723:
 /***/ (function(module, __unusedexports, __webpack_require__) {
 
@@ -11898,6 +12745,73 @@ function isexe (path, options, cb) {
 function sync (path, options) {
   return checkStat(fs.statSync(path), path, options)
 }
+
+
+/***/ }),
+
+/***/ 834:
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+"use strict";
+/*jshint node:true*/
+
+
+/**
+ * Replaces characters in strings that are illegal/unsafe for filenames.
+ * Unsafe characters are either removed or replaced by a substitute set
+ * in the optional `options` object.
+ *
+ * Illegal Characters on Various Operating Systems
+ * / ? < > \ : * | "
+ * https://kb.acronis.com/content/39790
+ *
+ * Unicode Control codes
+ * C0 0x00-0x1f & C1 (0x80-0x9f)
+ * http://en.wikipedia.org/wiki/C0_and_C1_control_codes
+ *
+ * Reserved filenames on Unix-based systems (".", "..")
+ * Reserved filenames in Windows ("CON", "PRN", "AUX", "NUL", "COM1",
+ * "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+ * "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", and
+ * "LPT9") case-insesitively and with or without filename extensions.
+ *
+ * Capped at 255 characters in length.
+ * http://unix.stackexchange.com/questions/32795/what-is-the-maximum-allowed-filename-and-folder-size-with-ecryptfs
+ *
+ * @param  {String} input   Original filename
+ * @param  {Object} options {replacement: String | Function }
+ * @return {String}         Sanitized filename
+ */
+
+var truncate = __webpack_require__(109);
+
+var illegalRe = /[\/\?<>\\:\*\|"]/g;
+var controlRe = /[\x00-\x1f\x80-\x9f]/g;
+var reservedRe = /^\.+$/;
+var windowsReservedRe = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$/i;
+var windowsTrailingRe = /[\. ]+$/;
+
+function sanitize(input, replacement) {
+  if (typeof input !== 'string') {
+    throw new Error('Input must be string');
+  }
+  var sanitized = input
+    .replace(illegalRe, replacement)
+    .replace(controlRe, replacement)
+    .replace(reservedRe, replacement)
+    .replace(windowsReservedRe, replacement)
+    .replace(windowsTrailingRe, replacement);
+  return truncate(sanitized, 255);
+}
+
+module.exports = function (input, options) {
+  var replacement = (options && options.replacement) || '';
+  var output = sanitize(input, replacement);
+  if (replacement === '') {
+    return output;
+  }
+  return sanitize(output, '');
+};
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -5309,7 +5309,7 @@ let sanitize = __webpack_require__(834);
 function generate(token, configYaml) {
     return __awaiter(this, void 0, void 0, function* () {
         console.log("Generating reports");
-        let configPath = path.join(__dirname, configYaml);
+        let configPath = path.join(process.env["GITHUB_WORKSPACE"], configYaml);
         let config = yaml.load(fs.readFileSync(configPath, 'utf-8'));
         let snapshot = {};
         snapshot.datetime = new Date();
@@ -5324,13 +5324,10 @@ function generate(token, configYaml) {
             report.details = {
                 time: util.getTimeForOffset(snapshot.datetime, report.timezoneOffset)
             };
-            console.log(report.details.time);
-            console.log(`Rendering ${report.name}`);
             report.name = mustache.render(report.name, {
                 config: config,
                 report: report
             });
-            console.log(report.name);
         }
         let outPath = yield writeSnapshot(snapshot);
         // hand that full data set to each report to render

--- a/generator.ts
+++ b/generator.ts
@@ -11,7 +11,7 @@ import {GeneratorConfiguration, ReportSnapshot, ReportConfig, ProjectsData, Proj
 export async function generate(token: string, configYaml: string): Promise<ReportSnapshot> {
     console.log("Generating reports");
 
-    let configPath = path.join(__dirname, configYaml);
+    let configPath = path.join(process.env["GITHUB_WORKSPACE"], configYaml);
     let config = <GeneratorConfiguration>yaml.load(fs.readFileSync(configPath, 'utf-8'))
 
     let snapshot = <ReportSnapshot>{};

--- a/generator.ts
+++ b/generator.ts
@@ -1,8 +1,12 @@
 import * as path from 'path'
 import * as fs from 'fs'
+import * as util from './util'
 import * as yaml from 'js-yaml'
 import * as github from './github'
-import {GeneratorConfiguration, ReportSnapshot, ReportConfiguration, ProjectsData, ProjectData, ProjectReport} from './interfaces'
+import * as mustache from 'mustache'
+let sanitize = require('sanitize-filename')
+
+import {GeneratorConfiguration, ReportSnapshot, ReportConfig, ProjectsData, ProjectData, ProjectReport, ReportDetails} from './interfaces'
 
 export async function generate(token: string, configYaml: string): Promise<ReportSnapshot> {
     console.log("Generating reports");
@@ -20,35 +24,52 @@ export async function generate(token: string, configYaml: string): Promise<Repor
     // load up the projects, their columns and all the issue cards + events.
     let projectsData: ProjectsData = await loadProjectsData(token, config);
 
+    // update report config details
+    for (const report of config.reports) {
+        report.timezoneOffset = report.timezoneOffset || -8;
+
+        report.details = <ReportDetails>{
+            time: util.getTimeForOffset(snapshot.datetime, report.timezoneOffset)
+        }
+
+        report.name = mustache.render(report.name, {
+            config: config,
+            report: report
+        });
+    }
+
     let outPath = await writeSnapshot(snapshot);
 
     // hand that full data set to each report to render
     for (const proj in projectsData) {
         const projectData = projectsData[proj];
 
-        for (const reportConfig of config.reports) {
-            console.log(`Generating ${reportConfig.name} for ${proj} ...`);
+        for (const report of config.reports) {
+            let output = "";
+            console.log(`Generating ${report.name} for ${proj} ...`);
 
-            // TODO: offer a config setting for the report path.
-            //       this will allow reports to be cloned and run 
-            let reportModule = `./reports/${reportConfig.name}`;
-            if (!fs.existsSync(path.join(__dirname, `${reportModule}.js`))) {
-                throw new Error(`Report not found: ${reportConfig.name}`);
+            for (const reportSection of report.sections) {
+                // TODO: offer a config setting for the report path.
+                //       this will allow reports to be cloned and run 
+                let reportModule = `./reports/${reportSection.name}`;
+                if (!fs.existsSync(path.join(__dirname, `${reportModule}.js`))) {
+                    throw new Error(`Report not found: ${report.name}`);
+                }
+        
+                // run as many reports as we can but fail action if any failed.
+                let failed = [];
+                try {
+                    let report = require(reportModule) as ProjectReport;
+        
+                    let processed = report.process(projectData);
+                    output += report.render(processed);
+                }
+                catch (err) {
+                    console.error(`Failed: ${err.message}`);
+                    failed.push({ report: report.name, error: err })
+                }
             }
-    
-            // run as many reports as we can but fail action if any failed.
-            let failed = [];
-            try {
-                let report = require(reportModule) as ProjectReport;
-    
-                let processed = report.process(projectData);
-                let contents = report.render(processed);
-                writeReport(outPath, reportConfig, projectData, contents);
-            }
-            catch (err) {
-                console.error(`Failed: ${err.message}`);
-                failed.push({ report: reportConfig.name, error: err })
-            }
+            writeReport(outPath, report, projectData, output);            
         }
     }
 
@@ -75,8 +96,8 @@ async function writeSnapshot(snapshot: ReportSnapshot): Promise<string> {
     return snapshotPath;
 }
 
-async function writeReport(basePath: string, reportConfig: ReportConfiguration, projectData: ProjectData, contents: string) {
-    const reportPath = path.join(basePath, reportConfig.name);
+async function writeReport(basePath: string, report: ReportConfig, projectData: ProjectData, contents: string) {
+    const reportPath = path.join(basePath, sanitize(report.name));
     if (!fs.existsSync(reportPath)) {
         fs.mkdirSync(reportPath);
     }

--- a/interfaces.ts
+++ b/interfaces.ts
@@ -1,6 +1,17 @@
-export interface ReportConfiguration {
+export interface ReportSection {
     name: string,
     configuration: any
+}
+
+export interface ReportDetails {
+    time: string
+}
+
+export interface ReportConfig {
+    name: string,
+    timezoneOffset: number,
+    sections: ReportSection[],
+    details: ReportDetails
 }
 
 export interface GeneratorConfiguration {
@@ -9,7 +20,7 @@ export interface GeneratorConfiguration {
     projects: string[],
     filter: string,
     output: string,
-    reports: ReportConfiguration[]    
+    reports: ReportConfig[]    
 }
 
 export interface ReportSnapshotData {

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,6 +141,12 @@
       "integrity": "sha512-JCcp6J0GV66Y4ZMDAQCXot4xprYB+Zfd3meK9+INSJeVZwJmHAW30BBEEkPzXswMXuiyReUGOP3GxrADc9wPww==",
       "dev": true
     },
+    "@types/mustache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.0.1.tgz",
+      "integrity": "sha512-wH6Tu9mbiOt0n5EvdoWy0VGQaJMHfLIxY/6wS0xLC7CV1taM6gESEzcYy0ZlWvxxiiljYvfDIvz4hHbUUDRlhw==",
+      "dev": true
+    },
     "@types/node": {
       "version": "14.0.23",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.23.tgz",
@@ -261,6 +267,11 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
+    "mustache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
+      "integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -323,6 +334,14 @@
         "once": "^1.3.1"
       }
     },
+    "sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "requires": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -383,6 +402,14 @@
         "split-text-to-chunks": "^1.0.0"
       }
     },
+    "truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "requires": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
     "tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
@@ -414,6 +441,11 @@
       "requires": {
         "upper-case": "^1.1.1"
       }
+    },
+    "utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,13 @@
     "@actions/github": "^4.0.0",
     "@octokit/rest": "^18.0.0",
     "js-yaml": "^3.14.0",
+    "mustache": "^4.0.1",
+    "sanitize-filename": "^1.6.3",
     "tablemark": "^2.0.0"
   },
   "devDependencies": {
     "@types/js-yaml": "^3.12.5",
+    "@types/mustache": "^4.0.1",
     "@types/node": "^14.0.23",
     "@zeit/ncc": "^0.22.3",
     "typescript": "^3.9.6"

--- a/samples/sample.yaml
+++ b/samples/sample.yaml
@@ -13,12 +13,15 @@ projects:
 output: "_reports"
 
 reports:
-  - name: "echo-board"
-    config:
-      add-age: "hours"
-  - name: "wip-limits"
-    config:
-      add-age: "hours"
+  - name: "{{{ config.name }}} Summary {{{ report.details.time }}}" 
+    timezoneOffset: -8
+    sections:
+      - name: "wip-limits"
+        config:
+          add-age: "hours"
+      - name: "echo-board"
+        config:
+          add-age: "hours"          
 
 
 

--- a/util.ts
+++ b/util.ts
@@ -1,0 +1,5 @@
+export function getTimeForOffset(date: Date, offset: number) {
+    var utc = date.getTime() + (date.getTimezoneOffset() * 60000);
+    var nd = new Date(utc + (3600000*offset));
+    return nd.toLocaleString();
+}


### PR DESCRIPTION
Config has a report level and refers to each of the report builders as sections.

This allows for composing large team reports in one view

See sample.yaml
```yaml
reports:
  - name: "{{{ config.name }}} Summary {{{ report.details.time }}}" 
    timezoneOffset: -8
    sections:
      - name: "wip-limits"
        config:
          add-age: "hours"
      - name: "echo-board"
        config:
          add-age: "hours"  
```

Also added the ability to format in config and report data into the report name.  Will take further later potentially.